### PR TITLE
added possibility to overwrite DefaultPluginManager (to create f.i. a JarPluginManager)

### DIFF
--- a/pf4j/src/main/java/ro/fortsoft/pf4j/DefaultExtensionFactory.java
+++ b/pf4j/src/main/java/ro/fortsoft/pf4j/DefaultExtensionFactory.java
@@ -16,8 +16,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The default implementation for ExtensionFactory.
- * It uses Class.newInstance() method.
+ * The default implementation for ExtensionFactory. It uses Class.newInstance()
+ * method.
  *
  * @author Decebal Suiu
  */
@@ -26,9 +26,11 @@ public class DefaultExtensionFactory implements ExtensionFactory {
     private static final Logger log = LoggerFactory.getLogger(DefaultExtensionFactory.class);
 
     /**
-     * Creates an extension instance. If an error occurs than that error is logged and the method returns null.
+     * Creates an extension instance. If an error occurs than that error is
+     * logged and the method returns null.
+     *
      * @param extensionClass
-     * @return
+     * @return an extension instance
      */
     @Override
     public Object create(Class<?> extensionClass) {

--- a/pf4j/src/main/java/ro/fortsoft/pf4j/DefaultPluginFactory.java
+++ b/pf4j/src/main/java/ro/fortsoft/pf4j/DefaultPluginFactory.java
@@ -31,7 +31,7 @@ public class DefaultPluginFactory implements PluginFactory {
     /**
      * Creates a plugin instance. If an error occurs than that error is logged and the method returns null.
      * @param pluginWrapper
-     * @return
+     * @return a plugin instance
      */
     @Override
     public Plugin create(final PluginWrapper pluginWrapper) {

--- a/pf4j/src/main/java/ro/fortsoft/pf4j/DefaultPluginManager.java
+++ b/pf4j/src/main/java/ro/fortsoft/pf4j/DefaultPluginManager.java
@@ -131,6 +131,23 @@ public class DefaultPluginManager implements PluginManager {
         initialize();
     }
 
+    /**
+     * Returns the currently used direcotry containing the plugins
+     * @return File pointing to the plugins directory
+     */
+    public File getPluginsDirectory() {
+        return pluginsDirectory;
+    }
+
+    /**
+     * Returns the PluginClasspath used by this plugin manager
+     * @return  the classpath used by this manager
+     */
+    protected PluginClasspath getPluginClasspath() {
+        return pluginClasspath;
+    }
+    
+
     @Override
     public void setSystemVersion(Version version) {
     	systemVersion = version;
@@ -689,7 +706,7 @@ public class DefaultPluginManager implements PluginManager {
      * If getRuntimeMode() returns RuntimeMode.DEVELOPMENT than a
 	 * DEVELOPMENT_PLUGINS_DIRECTORY ("../plugins") is returned else this method returns
 	 * DEFAULT_PLUGINS_DIRECTORY ("plugins").
-     * @return
+     * @return File pointing to the plugins directory
      */
     protected File createPluginsDirectory() {
     	String pluginsDir = System.getProperty("pf4j.pluginsDir");

--- a/pf4j/src/main/java/ro/fortsoft/pf4j/PluginManager.java
+++ b/pf4j/src/main/java/ro/fortsoft/pf4j/PluginManager.java
@@ -18,8 +18,8 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Provides the functionality for plugin management such as load,
- * start and stop the plugins.
+ * Provides the functionality for plugin management such as load, start and stop
+ * the plugins.
  *
  * @author Decebal Suiu
  */
@@ -38,12 +38,12 @@ public interface PluginManager {
     /**
      * Retrieves all resolved plugins (with resolved dependency).
      */
-  	public List<PluginWrapper> getResolvedPlugins();
+    public List<PluginWrapper> getResolvedPlugins();
 
-	/**
-	 * Retrieves all unresolved plugins (with unresolved dependency).
-	 */
-  	public List<PluginWrapper> getUnresolvedPlugins();
+    /**
+     * Retrieves all unresolved plugins (with unresolved dependency).
+     */
+    public List<PluginWrapper> getUnresolvedPlugins();
 
     /**
      * Retrieves all started plugins.
@@ -69,7 +69,7 @@ public interface PluginManager {
      * @param pluginArchiveFile
      * @return the pluginId of the installed plugin or null
      */
-	public String loadPlugin(File pluginArchiveFile);
+    public String loadPlugin(File pluginArchiveFile);
 
     /**
      * Start all active plugins.
@@ -127,27 +127,27 @@ public interface PluginManager {
      */
     public boolean deletePlugin(String pluginId);
 
-	public PluginClassLoader getPluginClassLoader(String pluginId);
+    public PluginClassLoader getPluginClassLoader(String pluginId);
 
-	public <T> List<T> getExtensions(Class<T> type);
+    public <T> List<T> getExtensions(Class<T> type);
 
     public Set<String> getExtensionClassNames(String pluginId);
 
     /**
-	 * The runtime mode. Must currently be either DEVELOPMENT or DEPLOYMENT.
-	 */
-	public RuntimeMode getRuntimeMode();
+     * The runtime mode. Must currently be either DEVELOPMENT or DEPLOYMENT.
+     * @return the runtime mode
+     */
+    public RuntimeMode getRuntimeMode();
 
     public void addPluginStateListener(PluginStateListener listener);
 
     public void removePluginStateListener(PluginStateListener listener);
 
     /**
-     * Set the system version.  This is used to compare against the plugin
-     * requires attribute.  The default system version is 0.0.0 which
-     * disables all version checking.
+     * Set the system version. This is used to compare against the plugin
+     * requires attribute. The default system version is 0.0.0 which disables
+     * all version checking.
      *
-     * @default 0.0.0
      * @param version
      */
     public void setSystemVersion(Version version);


### PR DESCRIPTION
To create an "JarPluginManager" that uses JARs (f.i. created with Maven Assembly "jar-with-dependencies") instead of ZIP, I needed to add two get-methods to DefaultPluginManager.

And while adding those two get-methods, I also updated javadoc to keep maven javadoc generation happy.

Here is my JarPluginManager implementation incl. demo program:

https://gist.github.com/tuxedo0801/0bc4ad265131b2d46643

Instead of the long configuration part in plugin's pom,xml + assembly xml, you now only need this in the pom (just an example):

....
    <properties>
    <!-- PF4J Plugin Settings -->
        <plugin.id>knx-logic-plugin</plugin.id>
        <plugin.class>de.root1.kad.logicplugin.LogicPlugin</plugin.class>
        <plugin.version>1.0.0</plugin.version>
        <plugin.provider>AC</plugin.provider>
        <plugin.dependencies></plugin.dependencies>    
    </properties>
....
    <build>
        <plugins>
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-assembly-plugin</artifactId>
                <version>2.5.4</version>
                <configuration>
                    <archive>
                        <manifestEntries>
                            <Plugin-Id>${plugin.id}</Plugin-Id>
                            <Plugin-Class>${plugin.class}</Plugin-Class>
                            <Plugin-Version>${plugin.version}</Plugin-Version>
                            <Plugin-Provider>${plugin.provider}</Plugin-Provider>
                            <Plugin-Dependencies>${plugin.dependencies}</Plugin-Dependencies>
                        </manifestEntries>
                    </archive>
                    <descriptorRefs>
                        <descriptorRef>jar-with-dependencies</descriptorRef>
                    </descriptorRefs>
                </configuration>
                <!-- extend phase package to assembly the archives -->
                <executions>
                    <execution>
                        <id>make-assembly</id>
                        <phase>package</phase>
                        <goals>
                            <goal>single</goal>
                        </goals>
                    </execution>
                </executions>
            </plugin>	            
        </plugins>
    </build>
....

That creates an JAR archive with "-jar-with-dependencies.jar" suffix/extension which includes all classes from dependencies.

One could also think of skipping the plugin-extraction-process and just pass the JAR to the classloader. But for improved startup-speed on small systems (Raspberry Pi f.i.) it could be a good idea to extract the JAR.