### PR TITLE
Fix "URI is not hierarchical" issue

### DIFF
--- a/pf4j/src/main/java/ro/fortsoft/pf4j/PluginClassLoader.java
+++ b/pf4j/src/main/java/ro/fortsoft/pf4j/PluginClassLoader.java
@@ -101,7 +101,7 @@ public class PluginClassLoader extends URLClassLoader {
                 }
             }
 
-            log.debug("Couldn't find class '{}' in plugin classpath. Delegating to parent");
+            log.debug("Couldn't find class '{}' in plugin classpath. Delegating to parent", className);
 
             // use the standard URLClassLoader (which follows normal parent delegation)
             return super.loadClass(className);


### PR DESCRIPTION
Pull request #87 fixed this problem for `readClasspathStorages()` but not for `readPluginsStorages()`. This applies the same fix.
