### PR TITLE
Used plugin2 as a example project on how to handly 3rd party libraries with gradle

### DIFF
--- a/demo_gradle/.gitignore
+++ b/demo_gradle/.gitignore
@@ -1,2 +1,4 @@
 build
 .gradle
+
+app/plugins

--- a/demo_gradle/api/src/main/java/ro/fortsoft/pf4j/demo/api/Greeting.java
+++ b/demo_gradle/api/src/main/java/ro/fortsoft/pf4j/demo/api/Greeting.java
@@ -1,4 +1,4 @@
-/*
+package ro.fortsoft.pf4j.demo.api;/*
  * Copyright 2012 Decebal Suiu
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- */
-package ro.fortsoft.pf4j.demo.api;
 
 import ro.fortsoft.pf4j.ExtensionPoint;
 

--- a/demo_gradle/plugins/plugin2/build.gradle
+++ b/demo_gradle/plugins/plugin2/build.gradle
@@ -1,25 +1,38 @@
 jar {
   baseName = 'HelloPlugin'
-  version = '0.1.0'
   manifest {
-    attributes 'Plugin-Class' : 'ro.fortsoft.pf4j.demo.welcome.HelloPlugin',
+    attributes 'Plugin-Class' : 'ro.fortsoft.pf4j.demo.hello.HelloPlugin',
       'Plugin-Id' : 'HelloPlugin',
       'Plugin-Version' : '1.0',
       'Plugin-Provider' : 'Decebal Suiu'
   }
 }
 
-task plugin(type: Jar) {
-  baseName = 'HelloPlugin'
-  version = '0.1.0'
-  into('classes')
-  extension('zip')
-  with jar
+configurations {
+    includeInJar
 }
 
 dependencies {
-  compile project(':api')
-  compile 'ro.fortsoft.pf4j:pf4j:0.4'
-  compile 'org.apache.commons:commons-lang3:3.0'
-  testCompile group: 'junit', name: 'junit', version: '4.+'
+    includeInJar 'org.json:json:20160212'
+
+    compile project(':api')
+    compile 'ro.fortsoft.pf4j:pf4j:0.4'
+    compile 'org.apache.commons:commons-lang3:3.0'
+    testCompile group: 'junit', name: 'junit', version: '4.+'
+
+    configurations.compile.extendsFrom(configurations.includeInJar)
+}
+
+
+task plugin(type: Jar, dependsOn: classes) {
+  into('../lib') {
+      println "includeInJar: " + configurations.includeInJar.collect { File file -> file }
+      from configurations.includeInJar
+  }
+
+  baseName = 'HelloPlugin'
+  version = '0.1.0'
+  with jar
+  into('classes')
+  extension('zip')
 }

--- a/demo_gradle/plugins/plugin2/src/main/java/ro/fortsoft/pf4j/demo/hello/HelloPlugin.java
+++ b/demo_gradle/plugins/plugin2/src/main/java/ro/fortsoft/pf4j/demo/hello/HelloPlugin.java
@@ -15,6 +15,7 @@
  */
 package ro.fortsoft.pf4j.demo.hello;
 
+import org.json.JSONObject;
 import ro.fortsoft.pf4j.Extension;
 import ro.fortsoft.pf4j.Plugin;
 import ro.fortsoft.pf4j.PluginWrapper;
@@ -46,7 +47,9 @@ public class HelloPlugin extends Plugin {
 
     	@Override
         public String getGreeting() {
-            return "Hello";
+            JSONObject json = new JSONObject("{'Class': 'HelloPlugin', 'Message': 'Hello'}");
+
+            return json.getString("Class") + ": " + json.getString("Message");
         }
 
     }


### PR DESCRIPTION
Libraries like org.json or something like that would be an example.
You basically need to pack them into: <name>.zip/lib/<library>.jar

Whenever you open the created zip in a file manager it may or may not display the "lib" directory properly but it's there. All those file managers can't display a path like: "<name>.zip/classes/../jar/<library>.jar" but the plugin manager can.

Also fixed a little copy paste error in plugin2/build.gradle. We don't work in the "welcome" package but in the "hello" package there.