### PR TITLE
getVersion() use wrong class for calculating PF4J version

### DIFF
--- a/pf4j/src/main/java/ro/fortsoft/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/ro/fortsoft/pf4j/AbstractPluginManager.java
@@ -612,7 +612,7 @@ public abstract class AbstractPluginManager implements PluginManager {
     public Version getVersion() {
         String version = null;
 
-        Package pf4jPackage = getClass().getPackage();
+        Package pf4jPackage = PluginManager.class.getPackage();
         if (pf4jPackage != null) {
             version = pf4jPackage.getImplementationVersion();
             if (version == null) {


### PR DESCRIPTION
I have a custom PluginManager, and when the `getVersion()` code attempts to log PF4J's version in initialize(), it uses `getClass()` to fetch implementationVersion. This assumes that getClass returns a PF4J class, but it returns my own class, which incidentially has a version not parsable by semVer Version class (it contains a space and git hash after the version string).

The fix is to always use a pf4j class for calculating the version.