### PR TITLE
The requires Expression does not print well

### DIFF
--- a/pf4j/src/main/java/ro/fortsoft/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/ro/fortsoft/pf4j/AbstractPluginManager.java
@@ -703,10 +703,11 @@ public abstract class AbstractPluginManager implements PluginManager {
             return true;
         }
 
-        log.warn("Plugin '{}:{}' requires a minimum system version of {}",
+        log.warn("Plugin '{}:{}' requires a minimum system version of {}, and you have {}",
             pluginWrapper.getPluginId(),
             pluginWrapper.getDescriptor().getVersion(),
-            requires);
+            pluginWrapper.getDescriptor().getRequiresString(),
+            system);
 
         return false;
     }

--- a/pf4j/src/main/java/ro/fortsoft/pf4j/PluginDescriptor.java
+++ b/pf4j/src/main/java/ro/fortsoft/pf4j/PluginDescriptor.java
@@ -37,6 +37,7 @@ public class PluginDescriptor {
     private String pluginClass;
     private Version version;
     private Expression requires;
+    private String requiresString;
     private String provider;
     private List<PluginDependency> dependencies;
     private String license;
@@ -82,6 +83,13 @@ public class PluginDescriptor {
     }
 
     /**
+     * Returns the requires of this plugin as a string.
+     */
+    public String getRequiresString() {
+        return requiresString;
+    }
+
+    /**
      * Returns the provider name of this plugin.
      */
     public String getProvider() {
@@ -108,7 +116,7 @@ public class PluginDescriptor {
 		return "PluginDescriptor [pluginId=" + pluginId + ", pluginClass="
 				+ pluginClass + ", version=" + version + ", provider="
 				+ provider + ", dependencies=" + dependencies + ", description="
-                + pluginDescription + ", requires=" + requires + ", license="
+                + pluginDescription + ", requires=" + requiresString + ", license="
 				+ license + "]";
 	}
 
@@ -133,6 +141,7 @@ public class PluginDescriptor {
     }
 
     void setRequires(String requires) {
+        requiresString = requires;
         Parser<Expression> parser = ExpressionParser.newInstance();
         setRequires(parser.parse(requires));
     }

--- a/pf4j/src/test/java/ro/fortsoft/pf4j/PropertiesPluginDescriptorFinderTest.java
+++ b/pf4j/src/test/java/ro/fortsoft/pf4j/PropertiesPluginDescriptorFinderTest.java
@@ -79,6 +79,7 @@ public class PropertiesPluginDescriptorFinderTest {
         assertEquals("test-plugin-3", plugin1.getDependencies().get(1).getPluginId());
         assertEquals("~1.0", plugin1.getDependencies().get(1).getPluginVersionSupport());
         assertEquals("Apache-2.0", plugin1.getLicense());
+        assertEquals("*", plugin1.getRequiresString());
         assertTrue(plugin1.getRequires().interpret(Version.valueOf("1.0.0")));
 
         assertEquals("test-plugin-2", plugin2.getPluginId());


### PR DESCRIPTION
Instead we get the className. As I could not find any method on Expression to convert back to String, this fix adds a `requiresString` variable to PluginInfo.