### PR TITLE
Ability to get pluginsRoot from PluginManager

### DIFF
--- a/pf4j/src/main/java/ro/fortsoft/pf4j/PluginManager.java
+++ b/pf4j/src/main/java/ro/fortsoft/pf4j/PluginManager.java
@@ -174,4 +174,9 @@ public interface PluginManager {
      */
     Version getSystemVersion();
 
+    /**
+     * Gets the path of the folder where plugins are installed
+     * @return Path of plugins root
+     */
+    public Path getPluginsRoot();
 }


### PR DESCRIPTION
Simple fix which will make https://github.com/decebals/pf4j-update/pull/11 more elegant