### PR TITLE
Updated gradle demo dependencies and switched from S.out.println to slf4j

### DIFF
--- a/demo_gradle/api/build.gradle
+++ b/demo_gradle/api/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compile 'ro.fortsoft.pf4j:pf4j:1.1.1'
+  compile 'ro.fortsoft.pf4j:pf4j:1.3.0'
   compile 'org.apache.commons:commons-lang3:3.0'
   testCompile group: 'junit', name: 'junit', version: '4.+'
 }

--- a/demo_gradle/app/build.gradle
+++ b/demo_gradle/app/build.gradle
@@ -4,10 +4,10 @@ mainClassName = 'ro.fortsoft.pf4j.demo.Boot'
 
 dependencies {
   compile project(':api')
-  compile 'ro.fortsoft.pf4j:pf4j:1.1.1'
-  compile 'org.apache.commons:commons-lang3:3.0'
+  compile 'ro.fortsoft.pf4j:pf4j:1.3.0'
+  compile 'org.apache.commons:commons-lang3:3.5'
   testCompile group: 'junit', name: 'junit', version: '4.+'
-  compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.6.1'
+  compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
 }
 
 jar {

--- a/demo_gradle/app/src/main/java/ro/fortsoft/pf4j/demo/Boot.java
+++ b/demo_gradle/app/src/main/java/ro/fortsoft/pf4j/demo/Boot.java
@@ -15,15 +15,15 @@
  */
 package ro.fortsoft.pf4j.demo;
 
-import java.util.List;
-import java.util.Set;
-
 import org.apache.commons.lang3.StringUtils;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import ro.fortsoft.pf4j.DefaultPluginManager;
 import ro.fortsoft.pf4j.PluginManager;
 import ro.fortsoft.pf4j.PluginWrapper;
 import ro.fortsoft.pf4j.demo.api.Greeting;
+
+import java.util.List;
 
 /**
  * A boot class that start the demo.
@@ -31,6 +31,7 @@ import ro.fortsoft.pf4j.demo.api.Greeting;
  * @author Decebal Suiu
  */
 public class Boot {
+    private static final Logger logger = LoggerFactory.getLogger(Boot.class);
 
     public static void main(String[] args) {
         // print logo
@@ -48,31 +49,31 @@ public class Boot {
         // start (active/resolved) the plugins
         pluginManager.startPlugins();
 
-        System.out.println("Plugindirectory: ");
-        System.out.println("\t" + System.getProperty("pf4j.pluginsDir", "plugins") + "\n");
+        logger.info("Plugindirectory: ");
+        logger.info("\t" + System.getProperty("pf4j.pluginsDir", "plugins") + "\n");
 
         // retrieves the extensions for Greeting extension point
         List<Greeting> greetings = pluginManager.getExtensions(Greeting.class);
-        System.out.println(String.format("Found %d extensions for extension point '%s'", greetings.size(), Greeting.class.getName()));
+        logger.info(String.format("Found %d extensions for extension point '%s'", greetings.size(), Greeting.class.getName()));
         for (Greeting greeting : greetings) {
-            System.out.println(">>> " + greeting.getGreeting());
+            logger.info(">>> " + greeting.getGreeting());
         }
 
         // // print extensions from classpath (non plugin)
-        // System.out.println(String.format("Extensions added by classpath:"));
+        // logger.info(String.format("Extensions added by classpath:"));
         // Set<String> extensionClassNames = pluginManager.getExtensionClassNames(null);
         // for (String extension : extensionClassNames) {
-        //     System.out.println("   " + extension);
+        //     logger.info("   " + extension);
         // }
 
         // print extensions for each started plugin
         List<PluginWrapper> startedPlugins = pluginManager.getStartedPlugins();
         for (PluginWrapper plugin : startedPlugins) {
             String pluginId = plugin.getDescriptor().getPluginId();
-            System.out.println(String.format("Extensions added by plugin '%s':", pluginId));
+            logger.info(String.format("Extensions added by plugin '%s':", pluginId));
             // extensionClassNames = pluginManager.getExtensionClassNames(pluginId);
             // for (String extension : extensionClassNames) {
-            //     System.out.println("   " + extension);
+            //     logger.info("   " + extension);
             // }
         }
 
@@ -91,9 +92,9 @@ public class Boot {
     }
 
 	private static void printLogo() {
-    	System.out.println(StringUtils.repeat("#", 40));
-    	System.out.println(StringUtils.center("PF4J-DEMO", 40));
-    	System.out.println(StringUtils.repeat("#", 40));
+    	logger.info(StringUtils.repeat("#", 40));
+    	logger.info(StringUtils.center("PF4J-DEMO", 40));
+    	logger.info(StringUtils.repeat("#", 40));
 	}
 
 }

--- a/demo_gradle/plugins/plugin1/build.gradle
+++ b/demo_gradle/plugins/plugin1/build.gradle
@@ -24,7 +24,9 @@ assemble.dependsOn plugin
 
 dependencies {
   compileOnly project(':api') // compileOnly important!!! We do not want to put the api into the zip file since the main program has it already!
-  compile 'ro.fortsoft.pf4j:pf4j:1.1.1'
-  compile 'org.apache.commons:commons-lang3:3.0'
+  compile ('ro.fortsoft.pf4j:pf4j:1.3.0') {
+      exclude group: "org.slf4j"
+  }
+  compile 'org.apache.commons:commons-lang3:3.5'
   testCompile group: 'junit', name: 'junit', version: '4.+'
 }

--- a/demo_gradle/plugins/plugin1/src/main/java/ro/fortsoft/pf4j/demo/welcome/WelcomePlugin.java
+++ b/demo_gradle/plugins/plugin1/src/main/java/ro/fortsoft/pf4j/demo/welcome/WelcomePlugin.java
@@ -17,6 +17,8 @@ package ro.fortsoft.pf4j.demo.welcome;
 
 import org.apache.commons.lang3.StringUtils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import ro.fortsoft.pf4j.Extension;
 import ro.fortsoft.pf4j.Plugin;
 import ro.fortsoft.pf4j.PluginWrapper;
@@ -26,6 +28,7 @@ import ro.fortsoft.pf4j.demo.api.Greeting;
  * @author Decebal Suiu
  */
 public class WelcomePlugin extends Plugin {
+    private static final Logger logger = LoggerFactory.getLogger(WelcomePlugin.class);
 
     public WelcomePlugin(PluginWrapper wrapper) {
         super(wrapper);
@@ -33,13 +36,13 @@ public class WelcomePlugin extends Plugin {
 
     @Override
     public void start() {
-        System.out.println("WelcomePlugin.start()");
-        	System.out.println(StringUtils.upperCase("WelcomePlugin"));
+        logger.info("WelcomePlugin.start()");
+        	logger.info(StringUtils.upperCase("WelcomePlugin"));
     }
 
     @Override
     public void stop() {
-        System.out.println("WelcomePlugin.stop()");
+        logger.info("WelcomePlugin.stop()");
     }
 
     @Extension

--- a/demo_gradle/plugins/plugin2/build.gradle
+++ b/demo_gradle/plugins/plugin2/build.gradle
@@ -24,7 +24,9 @@ assemble.dependsOn plugin
 
 dependencies {
   compileOnly project(':api') // compileOnly important!!! We do not want to put the api into the zip file since the main program has it already!
-  compile 'ro.fortsoft.pf4j:pf4j:1.1.1'
-  compile 'org.apache.commons:commons-lang3:3.0'
+  compile ('ro.fortsoft.pf4j:pf4j:1.3.0') {
+    exclude group: "org.slf4j"
+  }
+  compile 'org.apache.commons:commons-lang3:3.5'
   testCompile group: 'junit', name: 'junit', version: '4.+'
 }

--- a/demo_gradle/plugins/plugin2/src/main/java/ro/fortsoft/pf4j/demo/hello/HelloPlugin.java
+++ b/demo_gradle/plugins/plugin2/src/main/java/ro/fortsoft/pf4j/demo/hello/HelloPlugin.java
@@ -15,6 +15,8 @@
  */
 package ro.fortsoft.pf4j.demo.hello;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import ro.fortsoft.pf4j.Extension;
 import ro.fortsoft.pf4j.Plugin;
 import ro.fortsoft.pf4j.PluginWrapper;
@@ -26,6 +28,7 @@ import ro.fortsoft.pf4j.demo.api.Greeting;
  * @author Decebal Suiu
  */
 public class HelloPlugin extends Plugin {
+    private static final Logger logger = LoggerFactory.getLogger(HelloPlugin.class);
 
     public HelloPlugin(PluginWrapper wrapper) {
         super(wrapper);
@@ -33,12 +36,12 @@ public class HelloPlugin extends Plugin {
 
     @Override
     public void start() {
-        System.out.println("HelloPlugin.start()");
+        logger.info("HelloPlugin.start()");
     }
 
     @Override
     public void stop() {
-        System.out.println("HelloPlugin.stop()");
+        logger.info("HelloPlugin.stop()");
     }
 
     @Extension(ordinal=1)

--- a/demo_gradle/plugins/plugin3/build.gradle
+++ b/demo_gradle/plugins/plugin3/build.gradle
@@ -42,8 +42,10 @@ repositories {
 
 dependencies {
     compileOnly project(':api')
-    kapt 'ro.fortsoft.pf4j:pf4j:1.+'
-    compile 'org.apache.commons:commons-lang3:3.0'
+    kapt ('ro.fortsoft.pf4j:pf4j:1.3.0') {
+        exclude group: "org.slf4j"
+    }
+    compile 'org.apache.commons:commons-lang3:3.5'
     testCompile group: 'junit', name: 'junit', version: '4.+'
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
 }

--- a/demo_gradle/plugins/plugin3/src/main/kotlin/ro/fortsoft/pf4j/demo/kotlin/KotlinPlugin.kt
+++ b/demo_gradle/plugins/plugin3/src/main/kotlin/ro/fortsoft/pf4j/demo/kotlin/KotlinPlugin.kt
@@ -16,6 +16,7 @@
 package ro.fortsoft.pf4j.demo.kotlin
 
 import org.apache.commons.lang3.StringUtils
+import org.slf4j.LoggerFactory
 import ro.fortsoft.pf4j.Extension
 import ro.fortsoft.pf4j.Plugin
 import ro.fortsoft.pf4j.PluginWrapper
@@ -27,14 +28,15 @@ import ro.fortsoft.pf4j.demo.api.Greeting
  * @author Anindya Chatterjee
  */
 class KotlinPlugin(wrapper: PluginWrapper) : Plugin(wrapper) {
+    private val logger = LoggerFactory.getLogger(KotlinPlugin::class.java)
 
     override fun start() {
-        println("KotlinPlugin.start()")
-        println(StringUtils.upperCase("KotlinPlugin"))
+        logger.info("KotlinPlugin.start()")
+        logger.info(StringUtils.upperCase("KotlinPlugin"))
     }
 
     override fun stop() {
-        println("KotlinPlugin.stop()")
+        logger.info("KotlinPlugin.stop()")
     }
 }
 


### PR DESCRIPTION
Updated pf4j and commons gradle dependencies to newest version and changed all build settings so we can use slf4j in plugins#148 

we needed to exclude all slf4j libraries from all plugins to get them to work.