### PR TITLE
A demo with fewer/simpler maven configs

### DIFF
--- a/demo2/README.md
+++ b/demo2/README.md
@@ -1,0 +1,14 @@
+# Demo 2 Application
+
+This is an application to demonstrate the use of pf4j.
+This is a derived work of `../demo` project with following changes:
+
++ The pom.xml is unbelievingly simpler. No more complicated maven-plugin configurations.
++ No other XMLs except `pom.xml`. Not even `assembly.xml`
++ Uses plugin.properties
++ Everything is a .jar and the application runs without extracting the content.
+  Trying to avoid .zip and extractions since it requires write permissions at the runtime which maybe unavailable
+  to some users (especially many users share the same installation of application).
+
+
+Run `./run-demo.sh` from this directory for a demo.

--- a/demo2/api/pom.xml
+++ b/demo2/api/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.pf4j.demo</groupId>
+        <artifactId>pf4j-demo-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>pf4j-demo-api</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Demo Api</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.pf4j</groupId>
+            <artifactId>pf4j</artifactId>
+            <version>${pf4j.version}</version>
+            <!-- !!! VERY IMPORTANT -->
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/demo2/api/src/main/java/org/pf4j/demo/api/Greeting.java
+++ b/demo2/api/src/main/java/org/pf4j/demo/api/Greeting.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2012 Decebal Suiu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j.demo.api;
+
+import org.pf4j.ExtensionPoint;
+
+/**
+ * @author Decebal Suiu
+ */
+public interface Greeting extends ExtensionPoint {
+
+    String getGreeting();
+
+}

--- a/demo2/app/pom.xml
+++ b/demo2/app/pom.xml
@@ -44,6 +44,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/demo2/app/pom.xml
+++ b/demo2/app/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.pf4j.demo</groupId>
+        <artifactId>pf4j-demo-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>pf4j-demo-app</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Demo App</name>
+
+    <properties>
+        <exec.mainClass>org.pf4j.demo.Boot</exec.mainClass>
+        <slf4j.version>1.7.5</slf4j.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>${exec.mainClass}</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.pf4j</groupId>
+            <artifactId>pf4j</artifactId>
+            <version>${pf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.pf4j.demo</groupId>
+            <artifactId>pf4j-demo-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Logs -->
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.16</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.4</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/demo2/app/src/main/java/org/pf4j/demo/Boot.java
+++ b/demo2/app/src/main/java/org/pf4j/demo/Boot.java
@@ -15,14 +15,7 @@
  */
 package org.pf4j.demo;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
-import java.util.Properties;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
@@ -44,12 +37,7 @@ public class Boot {
 
         // create the plugin manager
 //        final PluginManager pluginManager = new DefaultPluginManager();
-        final PluginManager pluginManager = new JarPluginManager(){
-            @Override
-            protected PluginDescriptorFinder createPluginDescriptorFinder() {
-                return new JarPropsPluginDescriptorFinder();
-            }
-        };
+        final PluginManager pluginManager = new JarPluginManager();
 
         // load the plugins
         pluginManager.loadPlugins();
@@ -126,23 +114,4 @@ public class Boot {
     	System.out.println(StringUtils.center("PF4J-DEMO 2", 40));
     	System.out.println(StringUtils.repeat("#", 40));
 	}
-
-    private static class JarPropsPluginDescriptorFinder extends PropertiesPluginDescriptorFinder {
-        static final String DEFAULT_PROPERTIES_FILE_NAME = "plugin.properties";
-
-        @Override
-        protected Properties readProperties(Path pluginPath) throws PluginException {
-            //TODO: submit this patch to main code base
-            try (FileSystem fileSystem = FileSystems.newFileSystem(pluginPath, this.getClass().getClassLoader());) {
-                // this way we can access files from .zip or .jar without extracting them
-                try (InputStream stream = Files.newInputStream(fileSystem.getPath(DEFAULT_PROPERTIES_FILE_NAME))) {
-                   Properties props = new Properties();
-                   props.load(stream);
-                   return props;
-                }
-            } catch (IOException e) {
-                throw new PluginException(e);
-            }
-        }
-    }
 }

--- a/demo2/app/src/main/java/org/pf4j/demo/Boot.java
+++ b/demo2/app/src/main/java/org/pf4j/demo/Boot.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2012 Decebal Suiu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j.demo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+
+import org.pf4j.*;
+import org.pf4j.demo.api.Greeting;
+
+/**
+ * A boot class that start the demo.
+ *
+ * @author Decebal Suiu, and Thamme Gowda
+ */
+public class Boot {
+
+
+    public static void main(String[] args) {
+        // print logo
+        printLogo();
+
+        // create the plugin manager
+//        final PluginManager pluginManager = new DefaultPluginManager();
+        final PluginManager pluginManager = new JarPluginManager(){
+            @Override
+            protected PluginDescriptorFinder createPluginDescriptorFinder() {
+                return new JarPropsPluginDescriptorFinder();
+            }
+        };
+
+        // load the plugins
+        pluginManager.loadPlugins();
+
+        // enable a disabled plugin
+//        pluginManager.enablePlugin("welcome-plugin");
+
+        // start (active/resolved) the plugins
+        pluginManager.startPlugins();
+
+        // retrieves the extensions for Greeting extension point
+        List<Greeting> greetings = pluginManager.getExtensions(Greeting.class);
+        System.out.println(String.format("Found %d extensions for extension point '%s'", greetings.size(), Greeting.class.getName()));
+        for (Greeting greeting : greetings) {
+            System.out.println(">>> " + greeting.getGreeting());
+        }
+
+        // print extensions from classpath (non plugin)
+        System.out.println("Extensions added by classpath:");
+        Set<String> extensionClassNames = pluginManager.getExtensionClassNames(null);
+        for (String extension : extensionClassNames) {
+            System.out.println("   " + extension);
+        }
+
+        // print extensions ids for each started plugin
+        List<PluginWrapper> startedPlugins = pluginManager.getStartedPlugins();
+        for (PluginWrapper plugin : startedPlugins) {
+            String pluginId = plugin.getDescriptor().getPluginId();
+            System.out.println(String.format("Extensions added by plugin '%s':", pluginId));
+            extensionClassNames = pluginManager.getExtensionClassNames(pluginId);
+            for (String extension : extensionClassNames) {
+                System.out.println("   " + extension);
+            }
+        }
+
+        // print the extensions instances for Greeting extension point for each started plugin
+        for (PluginWrapper plugin : startedPlugins) {
+            String pluginId = plugin.getDescriptor().getPluginId();
+            System.out.println(String.format("Extensions instances added by plugin '%s' for extension point '%s':", pluginId, Greeting.class.getName()));
+            List<Greeting> extensions = pluginManager.getExtensions(Greeting.class, pluginId);
+            for (Object extension : extensions) {
+                System.out.println("   " + extension);
+            }
+        }
+
+        // print extensions instances from classpath (non plugin)
+        System.out.println("Extensions instances added by classpath:");
+        List extensions = pluginManager.getExtensions((String) null);
+        for (Object extension : extensions) {
+            System.out.println("   " + extension);
+        }
+
+        // print extensions instances for each started plugin
+        for (PluginWrapper plugin : startedPlugins) {
+            String pluginId = plugin.getDescriptor().getPluginId();
+            System.out.println(String.format("Extensions instances added by plugin '%s':", pluginId));
+            extensions = pluginManager.getExtensions(pluginId);
+            for (Object extension : extensions) {
+                System.out.println("   " + extension);
+            }
+        }
+
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+
+			@Override
+			public void run() {
+				pluginManager.stopPlugins();
+			}
+        });
+    }
+
+	private static void printLogo() {
+    	System.out.println(StringUtils.repeat("#", 40));
+    	System.out.println(StringUtils.center("PF4J-DEMO 2", 40));
+    	System.out.println(StringUtils.repeat("#", 40));
+	}
+
+    private static class JarPropsPluginDescriptorFinder extends PropertiesPluginDescriptorFinder {
+        static final String DEFAULT_PROPERTIES_FILE_NAME = "plugin.properties";
+
+        @Override
+        protected Properties readProperties(Path pluginPath) throws PluginException {
+            //TODO: submit this patch to main code base
+            try (FileSystem fileSystem = FileSystems.newFileSystem(pluginPath, this.getClass().getClassLoader());) {
+                // this way we can access files from .zip or .jar without extracting them
+                try (InputStream stream = Files.newInputStream(fileSystem.getPath(DEFAULT_PROPERTIES_FILE_NAME))) {
+                   Properties props = new Properties();
+                   props.load(stream);
+                   return props;
+                }
+            } catch (IOException e) {
+                throw new PluginException(e);
+            }
+        }
+    }
+}

--- a/demo2/app/src/main/java/org/pf4j/demo/HowdyGreeting.java
+++ b/demo2/app/src/main/java/org/pf4j/demo/HowdyGreeting.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 Decebal Suiu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j.demo;
+
+import org.pf4j.demo.api.Greeting;
+
+/**
+ * A Service Implementation (no @Extension) declared via Java Service Provider mechanism (using META-INF/services).
+ *
+ * @author Decebal Suiu
+ */
+public class HowdyGreeting implements Greeting {
+
+    @Override
+    public String getGreeting() {
+        return "Howdy";
+    }
+
+}

--- a/demo2/app/src/main/java/org/pf4j/demo/WhazzupGreeting.java
+++ b/demo2/app/src/main/java/org/pf4j/demo/WhazzupGreeting.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 Decebal Suiu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j.demo;
+
+import org.pf4j.Extension;
+import org.pf4j.demo.api.Greeting;
+
+/**
+ * @author Decebal Suiu
+ */
+@Extension
+public class WhazzupGreeting implements Greeting {
+
+    @Override
+    public String getGreeting() {
+        return "Whazzup";
+    }
+
+}

--- a/demo2/app/src/main/resources/META-INF/services/org.pf4j.demo.api.Greeting
+++ b/demo2/app/src/main/resources/META-INF/services/org.pf4j.demo.api.Greeting
@@ -1,0 +1,1 @@
+org.pf4j.demo.HowdyGreeting

--- a/demo2/app/src/main/resources/log4j.properties
+++ b/demo2/app/src/main/resources/log4j.properties
@@ -1,0 +1,20 @@
+log4j.rootLogger=DEBUG, Console
+
+#
+# PF4J log
+#
+log4j.logger.org.pf4j=DEBUG, Console
+# !!! Put the bellow classes on level TRACE when you are in trouble
+log4j.logger.org.pf4j.PluginClassLoader=DEBUG, Console
+log4j.logger.org.pf4j.AbstractExtensionFinder=DEBUG, Console
+log4j.additivity.org.pf4j=false
+log4j.additivity.org.pf4j.PluginClassLoader=false
+log4j.additivity.org.pf4j.AbstractExtensionFinder=false
+
+#
+# Appenders
+#
+log4j.appender.Console=org.apache.log4j.ConsoleAppender
+log4j.appender.Console.layout=org.apache.log4j.PatternLayout
+#log4j.appender.Console.layout.conversionPattern=%-5p - %-32.32c{1} - %m\n
+log4j.appender.Console.layout.ConversionPattern=%d %p %c - %m%n

--- a/demo2/plugins/disabled.txt
+++ b/demo2/plugins/disabled.txt
@@ -1,0 +1,6 @@
+########################################
+# - load all plugins except these
+# - add one plugin id on each line
+# - put this file in plugins folder
+########################################
+#welcome-plugin

--- a/demo2/plugins/enabled.txt
+++ b/demo2/plugins/enabled.txt
@@ -1,0 +1,6 @@
+########################################
+# - load only these plugins
+# - add one plugin id on each line
+# - put this file in plugins folder
+########################################
+#welcome-plugin

--- a/demo2/plugins/plugin1/pom.xml
+++ b/demo2/plugins/plugin1/pom.xml
@@ -23,7 +23,7 @@
         </dependency>
         <dependency>
             <!--
-            A trouble (or p*** in the a**) for java systems is coping with multiple transitive dependency versions.
+            A trouble for java systems is - dealing with multiple transitive dependency versions.
             This plugin uses version 6.0.0 of lucene ; other one will use 7.0.0
             to test whether the class loaders are setup correctly.
             -->

--- a/demo2/plugins/plugin1/pom.xml
+++ b/demo2/plugins/plugin1/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.pf4j.demo</groupId>
+        <artifactId>pf4j-demo-plugins</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>pf4j-demo-plugin1</artifactId>
+    <version>0.0.2-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Demo Plugin #1</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+        <dependency>
+            <!--
+            A trouble (or p*** in the a**) for java systems is coping with multiple transitive dependency versions.
+            This plugin uses version 6.0.0 of lucene ; other one will use 7.0.0
+            to test whether the class loaders are setup correctly.
+            -->
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>6.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <!-- Config is same as defined in the parent POM -->
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/demo2/plugins/plugin1/src/main/java/org/pf4j/demo/welcome/WelcomePlugin.java
+++ b/demo2/plugins/plugin1/src/main/java/org/pf4j/demo/welcome/WelcomePlugin.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012 Decebal Suiu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j.demo.welcome;
+
+import org.apache.commons.lang.StringUtils;
+
+import org.apache.lucene.util.Version;
+import org.pf4j.PluginWrapper;
+import org.pf4j.RuntimeMode;
+import org.pf4j.demo.api.Greeting;
+import org.pf4j.Extension;
+import org.pf4j.Plugin;
+
+/**
+ * @author Decebal Suiu
+ */
+public class WelcomePlugin extends Plugin {
+
+    public WelcomePlugin(PluginWrapper wrapper) {
+        super(wrapper);
+    }
+
+    @Override
+    public void start() {
+        System.out.println("WelcomePlugin.start()");
+        // for testing the development mode
+        if (RuntimeMode.DEVELOPMENT.equals(wrapper.getRuntimeMode())) {
+        	System.out.println(StringUtils.upperCase("WelcomePlugin"));
+        }
+    }
+
+    @Override
+    public void stop() {
+        System.out.println("WelcomePlugin.stop()");
+    }
+
+    @Extension
+    public static class WelcomeGreeting implements Greeting {
+
+    	@Override
+        public String getGreeting() {
+
+            return "Welcome. \tUsing Version: " + Version.LATEST;
+        }
+
+    }
+
+}

--- a/demo2/plugins/plugin1/src/main/resources/plugin.properties
+++ b/demo2/plugins/plugin1/src/main/resources/plugin.properties
@@ -1,0 +1,5 @@
+plugin.id=${project.artifactId}
+plugin.version=${project.version}
+plugin.class=org.pf4j.demo.welcome.WelcomePlugin
+plugin.provider=Decebal Suiu
+plugin.dependencies=

--- a/demo2/plugins/plugin2/pom.xml
+++ b/demo2/plugins/plugin2/pom.xml
@@ -17,7 +17,7 @@
     <dependencies>
         <dependency>
             <!--
-            A trouble (or p*** in the a**) for java systems is coping with multiple transitive dependency versions.
+            A trouble for java systems is - dealing with multiple transitive dependency versions.
             This plugin uses version 7.0.0 of lucene ; other one will use 6.0.0
             to test/demonstrate whether the class loaders are setup correctly
             -->

--- a/demo2/plugins/plugin2/pom.xml
+++ b/demo2/plugins/plugin2/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.pf4j.demo</groupId>
+        <artifactId>pf4j-demo-plugins</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>pf4j-demo-plugin2</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Demo Plugin #2</name>
+    <dependencies>
+        <dependency>
+            <!--
+            A trouble (or p*** in the a**) for java systems is coping with multiple transitive dependency versions.
+            This plugin uses version 7.0.0 of lucene ; other one will use 6.0.0
+            to test/demonstrate whether the class loaders are setup correctly
+            -->
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>7.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <!-- Config is same as defined in the parent POM -->
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/demo2/plugins/plugin2/src/main/java/org/pf4j/demo/hello/HelloPlugin.java
+++ b/demo2/plugins/plugin2/src/main/java/org/pf4j/demo/hello/HelloPlugin.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012 Decebal Suiu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pf4j.demo.hello;
+
+import org.apache.lucene.util.Version;
+import org.pf4j.Extension;
+import org.pf4j.Plugin;
+import org.pf4j.PluginWrapper;
+import org.pf4j.demo.api.Greeting;
+
+/**
+ * A very simple plugin.
+ *
+ * @author Decebal Suiu
+ */
+public class HelloPlugin extends Plugin {
+
+    public HelloPlugin(PluginWrapper wrapper) {
+        super(wrapper);
+    }
+
+    @Override
+    public void start() {
+        System.out.println("HelloPlugin.start()");
+    }
+
+    @Override
+    public void stop() {
+        System.out.println("HelloPlugin.stop()");
+    }
+
+    @Extension(ordinal=1)
+    public static class HelloGreeting implements Greeting {
+
+    	@Override
+        public String getGreeting() {
+            return "Hello \tUsing Version: " + Version.LATEST;
+        }
+
+    }
+
+}

--- a/demo2/plugins/plugin2/src/main/resources/plugin.properties
+++ b/demo2/plugins/plugin2/src/main/resources/plugin.properties
@@ -1,0 +1,5 @@
+plugin.id=${project.artifactId}
+plugin.version=${project.version}
+plugin.class=org.pf4j.demo.hello.HelloPlugin
+plugin.provider=Decebal Suiu
+plugin.dependencies=

--- a/demo2/plugins/pom.xml
+++ b/demo2/plugins/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.pf4j.demo</groupId>
+        <artifactId>pf4j-demo-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>pf4j-demo-plugins</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Demo Plugins Parent</name>
+
+    <modules> <!-- List all plugin project paths here -->
+        <module>plugin1</module>
+        <module>plugin2</module>
+    </modules>
+
+
+    <build>
+        <resources>
+            <resource> <!-- This will update variable with its values in resources
+                        e.g.: refer how plugin id and version are set in plugin.properties -->
+                <directory>src${file.separator}main${file.separator}resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <configuration>
+                        <descriptorRefs>
+                            <descriptorRef>jar-with-dependencies</descriptorRef>
+                        </descriptorRefs>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>make-assembly</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>single</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.pf4j</groupId>
+            <artifactId>pf4j</artifactId>
+            <version>${pf4j.version}</version>
+            <!-- !!! VERY IMPORTANT -->
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.pf4j.demo</groupId>
+            <artifactId>pf4j-demo-api</artifactId>
+            <version>${project.parent.version}</version>
+            <!-- !!! VERY IMPORTANT -->
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/demo2/pom.xml
+++ b/demo2/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.pf4j</groupId>
+        <artifactId>pf4j-parent</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.pf4j.demo</groupId>
+    <artifactId>pf4j-demo-parent</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Demo Parent</name>
+
+    <properties>
+        <javadoc.disabled>true</javadoc.disabled>
+        <deploy.disabled>true</deploy.disabled>
+        <source.disabled>true</source.disabled>
+        <pf4j.version>${project.parent.version}</pf4j.version>
+    </properties>
+
+    <modules>
+        <module>app</module>
+        <module>api</module>
+        <module>plugins</module>
+    </modules>
+</project>

--- a/demo2/run-demo.sh
+++ b/demo2/run-demo.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+#
+# This script creates and run the pf4j demo.
+#
+
+# create artifacts using maven
+mvn clean package
+
+# create demo-dist folder
+rm -fr demo-dist
+mkdir -p demo-dist/plugins
+
+# copy artifacts to demo-dist folder
+cp -r app/target/pf4j-demo-app-*-jar-with-dependencies.jar demo-dist/
+cp  plugins/plugin*/target/*-jar-with-dependencies.jar demo-dist/plugins/
+
+# run demo
+cd demo-dist
+java -jar pf4j-demo-app-*.jar
+cd -
+

--- a/pf4j/src/main/java/org/pf4j/PropertiesPluginDescriptorFinder.java
+++ b/pf4j/src/main/java/org/pf4j/PropertiesPluginDescriptorFinder.java
@@ -62,9 +62,11 @@ public class PropertiesPluginDescriptorFinder implements PluginDescriptorFinder 
             // For files inside .zip: Files.notExists() thinks the file exists, but Files.newInputStream() doesn't agree with it
             // So, to circumvent this, we open a FileSystem and close it at the end
             if (!Files.exists(propertiesPath)) {
-                fileSystem = FileSystems.newFileSystem(pluginPath, this.getClass().getClassLoader());
-                propertiesPath = fileSystem.getPath(propertiesFileName);
-                if (Files.notExists(propertiesPath)) {
+                if (pluginPath.endsWith(".zip") || pluginPath.endsWith(".jar")) {
+                    fileSystem = FileSystems.newFileSystem(pluginPath, this.getClass().getClassLoader());
+                    propertiesPath = fileSystem.getPath(propertiesFileName);
+                }
+                if (!Files.exists(propertiesPath)) {
                     throw new PluginException("Cannot find '{}' path", pluginPath);
                 }
             }

--- a/pf4j/src/main/java/org/pf4j/util/FileUtils.java
+++ b/pf4j/src/main/java/org/pf4j/util/FileUtils.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileReader;
@@ -197,6 +198,21 @@ public class FileUtils {
      */
     public static boolean isZipFile(Path path) {
         return Files.isRegularFile(path) && path.toString().toLowerCase().endsWith(".zip");
+    }
+
+    /**
+     * Closes an instance of closeable quietly.
+     * It is null safe and ignores IOExceptions that may atrise during close
+     * @param closeable object to be closed
+     */
+    public static void closeQuietly(Closeable closeable){
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException e) {
+                //Ignore
+            }
+        }
     }
 
 }


### PR DESCRIPTION
## Background
I was giving this project a test run to see if I can use this for [one of my project](https://github.com/USCDataScience/sparkler). I am very impressed; I am planning to swap this in the place of OSGI! __Thank you for developing this and making it available under Apache Licence 2.0.__
I looked into the demo app and felt that the maven configs can be a bit better and simpler.
So I went ahead and changed it (in the way I am planning to use in my project). and thought of submitting back.

## About this  PR
This is a derived work of `../demo` project with following changes:

+ The pom.xml is unbelievably simpler. No more complicated maven-plugin configurations.
+ No other XMLs except `pom.xml`. Not even `assembly.xml`
+ Uses plugin.properties, also the plugin versions are synchronized with maven artifact version (which will be updated with maven release plugin if configured).
+ Everything is a .jar and the application runs without extracting the content.
  Trying to avoid .zip and extractions since it requires write permissions at the runtime which may be unavailable to users (especially where many users share the same installation of the application).

PS: if you like to replace existing demo with this new demo, I will be happy to make those changes.