### PR TITLE
Improve public API of Extention* classes

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractExtensionFinder.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractExtensionFinder.java
@@ -219,18 +219,13 @@ public abstract class AbstractExtensionFinder implements ExtensionFinder, Plugin
     }
 
     private ExtensionWrapper createExtensionWrapper(Class<?> extensionClass) {
-        ExtensionDescriptor descriptor = new ExtensionDescriptor();
         int ordinal = 0;
         if (extensionClass.isAnnotationPresent(Extension.class)) {
             ordinal = extensionClass.getAnnotation(Extension.class).ordinal();
         }
-        descriptor.setOrdinal(ordinal);
-        descriptor.setExtensionClass(extensionClass);
+        ExtensionDescriptor descriptor = new ExtensionDescriptor(ordinal, extensionClass);
 
-        ExtensionWrapper extensionWrapper = new ExtensionWrapper<>(descriptor);
-        extensionWrapper.setExtensionFactory(pluginManager.getExtensionFactory());
-
-        return extensionWrapper;
+        return new ExtensionWrapper<>(descriptor, pluginManager.getExtensionFactory());
     }
 
     private void checkDifferentClassLoaders(Class<?> type, Class<?> extensionClass) {

--- a/pf4j/src/main/java/org/pf4j/ExtensionDescriptor.java
+++ b/pf4j/src/main/java/org/pf4j/ExtensionDescriptor.java
@@ -20,23 +20,12 @@ package org.pf4j;
  */
 public class ExtensionDescriptor {
 
-    private int ordinal;
-    private Class<?> extensionClass;
+    public final int ordinal;
+    public final Class<?> extensionClass;
 
-    public Class<?> getExtensionClass() {
-        return extensionClass;
-    }
-
-    public int getOrdinal() {
-        return ordinal;
-    }
-
-    void setExtensionClass(Class<?> extensionClass) {
-        this.extensionClass = extensionClass;
-    }
-
-    void setOrdinal(int ordinal) {
+    public ExtensionDescriptor(int ordinal, Class<?> extensionClass) {
         this.ordinal = ordinal;
+        this.extensionClass = extensionClass;
     }
 
 }

--- a/pf4j/src/main/java/org/pf4j/ExtensionWrapper.java
+++ b/pf4j/src/main/java/org/pf4j/ExtensionWrapper.java
@@ -22,18 +22,19 @@ package org.pf4j;
  */
 public class ExtensionWrapper<T> implements Comparable<ExtensionWrapper<T>> {
 
-    ExtensionDescriptor descriptor;
-    ExtensionFactory extensionFactory;
-    T extension; // cache
+    private final ExtensionDescriptor descriptor;
+    private final ExtensionFactory extensionFactory;
+    private T extension; // cache
 
-	public ExtensionWrapper(ExtensionDescriptor descriptor) {
+	public ExtensionWrapper(ExtensionDescriptor descriptor, ExtensionFactory extensionFactory) {
         this.descriptor = descriptor;
-	}
+        this.extensionFactory = extensionFactory;
+    }
 
 	@SuppressWarnings("unchecked")
     public T getExtension() {
         if (extension == null) {
-            extension = (T) extensionFactory.create(descriptor.getExtensionClass());
+            extension = (T) extensionFactory.create(descriptor.extensionClass);
         }
 
         return extension;
@@ -44,16 +45,12 @@ public class ExtensionWrapper<T> implements Comparable<ExtensionWrapper<T>> {
     }
 
     public int getOrdinal() {
-		return descriptor.getOrdinal();
+		return descriptor.ordinal;
 	}
 
 	@Override
 	public int compareTo(ExtensionWrapper<T> o) {
 		return (getOrdinal() - o.getOrdinal());
 	}
-
-    void setExtensionFactory(ExtensionFactory extensionFactory) {
-        this.extensionFactory = extensionFactory;
-    }
 
 }


### PR DESCRIPTION
`ExtensionWrapper` and `ExtensionDescriptor` have poor public API which doesn't allow using them outside of `org.pf4j` package, but these classes are parts of public API of pf4j library.

This change converts `ExtensionDescriptor` to be an immutable object with all public fields that cannot be changed after creation. Also, removed `setExtensionFactory` from `ExtensionWrapper` in favor of a constructor parameter.