### PR TITLE
Emit warning instead of error when plugin root is not present

### DIFF
--- a/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/AbstractPluginManager.java
@@ -208,7 +208,7 @@ public abstract class AbstractPluginManager implements PluginManager {
         log.debug("Lookup plugins in '{}'", pluginsRoot);
         // check for plugins root
         if (Files.notExists(pluginsRoot) || !Files.isDirectory(pluginsRoot)) {
-            log.error("No '{}' root", pluginsRoot);
+            log.warn("No '{}' root", pluginsRoot);
             return;
         }
 


### PR DESCRIPTION
The framework can properly function without plugins root by loading plugins from classpath so there is no reason to log an error, warning should be enough.