### PR TITLE
@Override should not change method signature

### DIFF
--- a/pf4j/src/main/java/org/pf4j/DefaultPluginManager.java
+++ b/pf4j/src/main/java/org/pf4j/DefaultPluginManager.java
@@ -52,7 +52,7 @@ public class DefaultPluginManager extends AbstractPluginManager {
     }
 
     @Override
-    protected CompoundPluginDescriptorFinder createPluginDescriptorFinder() {
+    protected PluginDescriptorFinder createPluginDescriptorFinder() {
         return new CompoundPluginDescriptorFinder()
             .add(new PropertiesPluginDescriptorFinder())
             .add(new ManifestPluginDescriptorFinder());


### PR DESCRIPTION
when subclassing `DefaultPluginManager` you are forced to create a `CompoundPluginDescriptorFinder` even if you only need one